### PR TITLE
[codex] Correct RoundTripper test typos

### DIFF
--- a/test/monitoring_tripper.go
+++ b/test/monitoring_tripper.go
@@ -5,17 +5,17 @@ import (
 	"net/http/httptest"
 )
 
-type MoniteringTripper struct {
+type MonitoringTripper struct {
 	TripCount int
 }
 
-func NewMoniteringTripper() *MoniteringTripper {
-	return &MoniteringTripper{
+func NewMonitoringTripper() *MonitoringTripper {
+	return &MonitoringTripper{
 		TripCount: 0,
 	}
 }
 
-func (t *MoniteringTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (t *MonitoringTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	w := httptest.NewRecorder()
 	w.WriteHeader(200)
 	w.Write([]byte("OK"))
@@ -24,6 +24,6 @@ func (t *MoniteringTripper) RoundTrip(req *http.Request) (*http.Response, error)
 	return w.Result(), nil
 }
 
-func (t *MoniteringTripper) Reset() {
+func (t *MonitoringTripper) Reset() {
 	t.TripCount = 0
 }

--- a/test/roundtripper_test.go
+++ b/test/roundtripper_test.go
@@ -11,13 +11,13 @@ import (
 )
 
 // RoundTripperTestSuite is a testify suite for RoundTripper
-type RounterTripperTestSuite struct {
+type RoundTripperTestSuite struct {
 	suite.Suite
 }
 
-func (s *RounterTripperTestSuite) TestUnlimited() {
+func (s *RoundTripperTestSuite) TestUnlimited() {
 	// dummy RoundTripper for test
-	monitor := NewMoniteringTripper()
+	monitor := NewMonitoringTripper()
 
 	// Create a new http client with unlimited limit
 	client := &http.Client{
@@ -59,9 +59,9 @@ func (s *RounterTripperTestSuite) TestUnlimited() {
 }
 
 // TestSimpleLimiter is a test for simple limiter
-func (s *RounterTripperTestSuite) TestSimpleLimiter() {
+func (s *RoundTripperTestSuite) TestSimpleLimiter() {
 	// dummy RoundTripper for test
-	monitor := NewMoniteringTripper()
+	monitor := NewMonitoringTripper()
 
 	// simple limiter for test
 	limiter := &simpleLimiter{
@@ -115,6 +115,6 @@ func (s *RounterTripperTestSuite) TestSimpleLimiter() {
 	}
 }
 
-func TestRounterTripper(t *testing.T) {
-	suite.Run(t, new(RounterTripperTestSuite))
+func TestRoundTripper(t *testing.T) {
+	suite.Run(t, new(RoundTripperTestSuite))
 }


### PR DESCRIPTION
## Summary

- Correct RoundTripper-related typoed test suite and test function names.
- Rename the monitoring test helper from `MoniteringTripper` to `MonitoringTripper`.

## Background

The test package had misspelled identifiers such as `RounterTripperTestSuite` and `TestRounterTripper`. A nearby helper used `MoniteringTripper`, so this PR corrects that typo at the same time.

## Related issue(s)

None.

## Implementation details

- Updated test suite and method receivers to use `RoundTripperTestSuite`.
- Updated the exported test entrypoint to `TestRoundTripper`.
- Renamed the monitoring helper file and identifiers to `MonitoringTripper`.

## Test coverage

- `make fmt`
- `make lint`
- `make test`

## Breaking changes

None. This only changes internal test package identifiers.

## Notes

Created by Codex
