### PR TITLE
[codex] Add RoundTripper constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The RoundTripper which rate-limits outbound HTTP requests.
 
 ## examples
 
+Use `rltransport.New(limiter)` to create a transport. Pass `nil` to disable rate limiting.
+
 ```golang
 package main
 
@@ -34,9 +36,7 @@ func main() {
 
 	// Create a new http.Client with the limiter.
 	client := &http.Client{
-		Transport: &rltransport.RoundTripper{
-			Limiter: limiter,
-		},
+		Transport: rltransport.New(limiter),
 	}
 
 	// Make a request to the server.

--- a/example/main.go
+++ b/example/main.go
@@ -25,9 +25,7 @@ func main() {
 
 	// Create a new http.Client with the limiter.
 	client := &http.Client{
-		Transport: &rltransport.RoundTripper{
-			Limiter: limiter,
-		},
+		Transport: rltransport.New(limiter),
 	}
 
 	// Make a request to the server.

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -20,6 +20,16 @@ type RoundTripper struct {
 	Transport http.RoundTripper
 }
 
+// New returns a RoundTripper that rate-limits requests with limiter.
+func New(limiter Limiter) *RoundTripper {
+	rt := &RoundTripper{
+		Limiter: limiter,
+	}
+	rt.init()
+
+	return rt
+}
+
 // RoundTrip satisfies the http.RoundTripper interface.
 func (rt *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Ensure that the Transport is initialized.

--- a/test/roundtripper_test.go
+++ b/test/roundtripper_test.go
@@ -115,6 +115,45 @@ func (s *RoundTripperTestSuite) TestSimpleLimiter() {
 	}
 }
 
+func (s *RoundTripperTestSuite) TestNew() {
+	limiter := &simpleLimiter{
+		Count: 0,
+		Limit: 1,
+	}
+
+	rt := rltransport.New(limiter)
+	assert.Same(s.T(), limiter, rt.Limiter)
+	assert.NotNil(s.T(), rt.Transport)
+
+	monitor := NewMonitoringTripper()
+	rt.Transport = monitor
+
+	client := &http.Client{
+		Transport: rt,
+	}
+
+	_, err := client.Get("http://example.com")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), 1, monitor.TripCount)
+}
+
+func (s *RoundTripperTestSuite) TestNewWithNilLimiter() {
+	rt := rltransport.New(nil)
+	assert.NotNil(s.T(), rt.Limiter)
+	assert.NotNil(s.T(), rt.Transport)
+
+	monitor := NewMonitoringTripper()
+	rt.Transport = monitor
+
+	client := &http.Client{
+		Transport: rt,
+	}
+
+	_, err := client.Get("http://example.com")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), 1, monitor.TripCount)
+}
+
 func TestRoundTripper(t *testing.T) {
 	suite.Run(t, new(RoundTripperTestSuite))
 }


### PR DESCRIPTION
## Summary

- Add `rltransport.New(limiter)` as the recommended constructor for `RoundTripper`.
- Update README and example usage to use the constructor.
- Add tests for constructor behavior with both custom and nil limiters.

## Background

Users currently need to construct `RoundTripper` with a struct literal. A small constructor improves discoverability and makes the common `http.Client` setup easier to read.

## Related issue(s)

None.

## Implementation details

- Added `New(limiter Limiter) *RoundTripper`.
- The constructor initializes default transport and unlimited limiter behavior consistently with the existing lazy initialization path.
- Existing public fields remain available for custom transport setup.

## Test coverage

- `make fmt`
- `make lint`
- `make test`
- `make ci`

## Breaking changes

None.

## Notes

Created by Codex
