### PR TITLE
[codex] Add RoundTripper concurrency race coverage

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,3 +53,23 @@ jobs:
 
       - name: Run lint
         run: make lint
+
+  race:
+    name: Race
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+          cache-dependency-path: |
+            go.sum
+            test/go.sum
+            example/go.sum
+
+      - name: Run race tests
+        run: make test-race

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,11 @@ test:
 	@cd test && go test $(TESTARGS) ./...
 	@cd example && go test $(TESTARGS) ./...
 
+## test-race: Run tests with the Go race detector
+.PHONY: test-race
+test-race:
+	@$(MAKE) test TESTARGS=-race
+
 ## lint: Run golangci-lint
 .PHONY: lint
 lint:
@@ -23,4 +28,4 @@ fmt:
 
 ## ci: Run lint and tests
 .PHONY: ci
-ci: lint test
+ci: lint test test-race

--- a/README.md
+++ b/README.md
@@ -62,3 +62,9 @@ To run both checks in the same order as CI:
 ```bash
 make ci
 ```
+
+Concurrency coverage is validated with the Go race detector (`go test -race`):
+
+```bash
+make test-race
+```

--- a/test/concurrent_limiter.go
+++ b/test/concurrent_limiter.go
@@ -1,0 +1,42 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+type concurrentLimiter struct {
+	mu    sync.Mutex
+	count int
+	limit int
+}
+
+func newConcurrentLimiter(limit int) *concurrentLimiter {
+	return &concurrentLimiter{
+		limit: limit,
+	}
+}
+
+func (l *concurrentLimiter) Wait(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.count >= l.limit {
+		return fmt.Errorf("limit exceeded")
+	}
+
+	l.count++
+	return nil
+}
+
+func (l *concurrentLimiter) Count() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return l.count
+}

--- a/test/monitoring_tripper.go
+++ b/test/monitoring_tripper.go
@@ -3,27 +3,40 @@ package test
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync"
 )
 
 type MonitoringTripper struct {
-	TripCount int
+	mu        sync.Mutex
+	tripCount int
 }
 
 func NewMonitoringTripper() *MonitoringTripper {
-	return &MonitoringTripper{
-		TripCount: 0,
-	}
+	return &MonitoringTripper{}
 }
 
 func (t *MonitoringTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	w := httptest.NewRecorder()
 	w.WriteHeader(200)
 	w.Write([]byte("OK"))
-	t.TripCount++
+
+	t.mu.Lock()
+	t.tripCount++
+	t.mu.Unlock()
 
 	return w.Result(), nil
 }
 
 func (t *MonitoringTripper) Reset() {
-	t.TripCount = 0
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.tripCount = 0
+}
+
+func (t *MonitoringTripper) Count() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return t.tripCount
 }

--- a/test/roundtripper_test.go
+++ b/test/roundtripper_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"net/http"
+	"sync"
 	"testing"
 
 	"github.com/HatsuneMiku3939/rltransport"
@@ -54,7 +55,7 @@ func (s *RoundTripperTestSuite) TestUnlimited() {
 		}
 
 		// Check the result
-		assert.Equalf(s.T(), c.want, monitor.TripCount, "sendCount: %d want %d", c.sendCount, c.want)
+		assert.Equalf(s.T(), c.want, monitor.Count(), "sendCount: %d want %d", c.sendCount, c.want)
 	}
 }
 
@@ -111,7 +112,7 @@ func (s *RoundTripperTestSuite) TestSimpleLimiter() {
 		}
 
 		// Check the result
-		assert.Equalf(s.T(), c.want, monitor.TripCount, "sendCount: %d want %d", c.sendCount, c.want)
+		assert.Equalf(s.T(), c.want, monitor.Count(), "sendCount: %d want %d", c.sendCount, c.want)
 	}
 }
 
@@ -134,7 +135,7 @@ func (s *RoundTripperTestSuite) TestNew() {
 
 	_, err := client.Get("http://example.com")
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), 1, monitor.TripCount)
+	assert.Equal(s.T(), 1, monitor.Count())
 }
 
 func (s *RoundTripperTestSuite) TestNewWithNilLimiter() {
@@ -151,7 +152,57 @@ func (s *RoundTripperTestSuite) TestNewWithNilLimiter() {
 
 	_, err := client.Get("http://example.com")
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), 1, monitor.TripCount)
+	assert.Equal(s.T(), 1, monitor.Count())
+}
+
+func (s *RoundTripperTestSuite) TestConcurrentRoundTrip() {
+	const (
+		workerCount       = 16
+		requestsPerWorker = 64
+	)
+	requestCount := workerCount * requestsPerWorker
+
+	monitor := NewMonitoringTripper()
+	limiter := newConcurrentLimiter(requestCount)
+	client := &http.Client{
+		Transport: &rltransport.RoundTripper{
+			Transport: monitor,
+			Limiter:   limiter,
+		},
+	}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make(chan error, requestCount)
+
+	for worker := 0; worker < workerCount; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+
+			for request := 0; request < requestsPerWorker; request++ {
+				resp, err := client.Get("http://example.com")
+				if err != nil {
+					errs <- err
+					continue
+				}
+				if resp != nil {
+					_ = resp.Body.Close()
+				}
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		assert.NoError(s.T(), err)
+	}
+	assert.Equal(s.T(), requestCount, monitor.Count())
+	assert.Equal(s.T(), requestCount, limiter.Count())
 }
 
 func TestRoundTripper(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add a concurrent RoundTripper test that drives many requests through one transport instance.
- Add `make test-race` and include race testing in local `make ci`.
- Add a dedicated GitHub Actions Race job and document race testing in README.

## Background

RoundTripper is intended to be used by `http.Client`, which may call transports concurrently. The test suite should cover that usage pattern and pass under the Go race detector.

## Related issue(s)

None.

## Implementation details

- Made the test monitoring transport safe for concurrent increments and reads.
- Added a concurrency-safe test limiter for race tests.
- Added `TestConcurrentRoundTrip` with synchronized goroutine start, aggregated errors, and final request count assertions.
- Added CI coverage for `make test-race`, which runs `go test -race` through the repository test modules.

## Test coverage

- `make test`
- `make test-race`
- `go test -race -count=1 ./...` in the root module
- `go test -race -count=1 ./...` in `test/`
- `go test -race -count=1 ./...` in `example/`
- `make lint`
- `make ci`

## Breaking changes

None.

## Notes

Created by Codex
