### PR TITLE
[codex] Add NewWithTransport constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ The RoundTripper which rate-limits outbound HTTP requests.
 
 ## examples
 
-Use `rltransport.New(limiter)` to create a transport. Pass `nil` to disable rate limiting.
+Use `rltransport.New(limiter)` to create a transport backed by `http.DefaultTransport`.
+Use `rltransport.NewWithTransport(limiter, transport)` to wrap a custom `http.RoundTripper`.
+Pass `nil` as the limiter to disable rate limiting, or `nil` as the transport to use `http.DefaultTransport`.
 
 ```golang
 package main

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -22,8 +22,15 @@ type RoundTripper struct {
 
 // New returns a RoundTripper that rate-limits requests with limiter.
 func New(limiter Limiter) *RoundTripper {
+	return NewWithTransport(limiter, nil)
+}
+
+// NewWithTransport returns a RoundTripper that rate-limits requests with
+// limiter and sends allowed requests to transport.
+func NewWithTransport(limiter Limiter, transport http.RoundTripper) *RoundTripper {
 	rt := &RoundTripper{
-		Limiter: limiter,
+		Limiter:   limiter,
+		Transport: transport,
 	}
 	rt.init()
 

--- a/test/roundtripper_test.go
+++ b/test/roundtripper_test.go
@@ -155,6 +155,78 @@ func (s *RoundTripperTestSuite) TestNewWithNilLimiter() {
 	assert.Equal(s.T(), 1, monitor.Count())
 }
 
+func (s *RoundTripperTestSuite) TestNewWithTransport() {
+	limiter := &simpleLimiter{
+		Count: 0,
+		Limit: 1,
+	}
+	monitor := NewMonitoringTripper()
+
+	cases := []struct {
+		name                 string
+		limiter              rltransport.Limiter
+		transport            http.RoundTripper
+		wantLimiter          rltransport.Limiter
+		wantTransport        http.RoundTripper
+		wantDefaultLimiter   bool
+		wantDefaultTransport bool
+		wantRequest          bool
+	}{
+		{
+			name:          "custom limiter and transport",
+			limiter:       limiter,
+			transport:     monitor,
+			wantLimiter:   limiter,
+			wantTransport: monitor,
+			wantRequest:   true,
+		},
+		{
+			name:               "nil limiter and custom transport",
+			transport:          monitor,
+			wantTransport:      monitor,
+			wantDefaultLimiter: true,
+			wantRequest:        true,
+		},
+		{
+			name:                 "custom limiter and nil transport",
+			limiter:              limiter,
+			wantLimiter:          limiter,
+			wantDefaultTransport: true,
+		},
+	}
+
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			monitor.Reset()
+			limiter.Reset()
+
+			rt := rltransport.NewWithTransport(c.limiter, c.transport)
+
+			if c.wantDefaultLimiter {
+				assert.NotNil(s.T(), rt.Limiter)
+			} else {
+				assert.Same(s.T(), c.wantLimiter, rt.Limiter)
+			}
+
+			if c.wantDefaultTransport {
+				assert.Same(s.T(), http.DefaultTransport, rt.Transport)
+			} else {
+				assert.Same(s.T(), c.wantTransport, rt.Transport)
+			}
+
+			if c.wantRequest {
+				client := &http.Client{
+					Transport: rt,
+				}
+
+				_, err := client.Get("http://example.com")
+				assert.NoError(s.T(), err)
+				assert.Equal(s.T(), 1, monitor.Count())
+			}
+		})
+	}
+}
+
 func (s *RoundTripperTestSuite) TestConcurrentRoundTrip() {
 	const (
 		workerCount       = 16


### PR DESCRIPTION
## Summary

Add `NewWithTransport(limiter, transport)` for constructing a rate-limited `RoundTripper` around a custom `http.RoundTripper`.

## Background

`New(limiter)` covers the default transport path, but callers that want to wrap a custom transport still need to construct `RoundTripper` directly. A dedicated constructor makes that usage clearer without changing the existing `New(limiter)` API.

## Related issue(s)

None.

## Implementation details

- Added `NewWithTransport(limiter Limiter, transport http.RoundTripper) *RoundTripper`.
- Updated `New(limiter)` to delegate to `NewWithTransport(limiter, nil)`.
- Preserved existing nil behavior: nil limiter disables rate limiting and nil transport uses `http.DefaultTransport`.
- Added table-driven tests for custom transport, nil limiter, and nil transport cases.
- Documented the constructor in README.

## Test coverage

- `make ci`
- `go test -count=1 ./...` in the root module
- `go test -count=1 ./...` in `test/`
- `go test -count=1 ./...` in `example/`
- `go test -race -count=1 ./...` in `test/`

## Breaking changes

None.

## Notes

Created by Codex