### PR TITLE
[codex] Make limiter request-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ The RoundTripper which rate-limits outbound HTTP requests.
 Use `rltransport.New(limiter)` to create a transport backed by `http.DefaultTransport`.
 Use `rltransport.NewWithTransport(limiter, transport)` to wrap a custom `http.RoundTripper`.
 Pass `nil` as the limiter to disable rate limiting, or `nil` as the transport to use `http.DefaultTransport`.
+Limiters receive the full `*http.Request`; wrap context-only limiters such as `golang.org/x/time/rate`
+with `rltransport.NewContextLimiter`.
 
-```golang
+```go
 package main
 
 import (
@@ -28,21 +30,21 @@ const (
 	TestBurstSize = 10
 	// TestRefillRate is the default value for the rate limiter's refill rate.
 	TestRefillRate = 1.0
-	// TestURL is the URL to use for testing.
+	// TestHost is the URL to use for testing.
 	TestHost = "http://localhost:8080/"
 )
 
 func main() {
-	// Create a "tocket bucket" limiter with a burst size of 10 and a refill rate of 1.0/sec.
+	// Create a token bucket limiter with a burst size of 10 and a refill rate of 1.0/sec.
 	limiter := rate.NewLimiter(TestRefillRate, TestBurstSize)
 
 	// Create a new http.Client with the limiter.
 	client := &http.Client{
-		Transport: rltransport.New(limiter),
+		Transport: rltransport.New(rltransport.NewContextLimiter(limiter)),
 	}
 
 	// Make a request to the server.
-	// First 10 requests will be sented immadiately, after that it will be sented by 1.0 req/sec.
+	// First 10 requests will be sent immediately, then requests will be sent at 1.0 req/sec.
 	for i := 0; i < 20; i++ {
 		res, _ := client.Get(TestHost)
 		fmt.Printf("[%s] %s\n", time.Now().Format("2006-01-02 15:04:05"), res.Status)

--- a/example/main.go
+++ b/example/main.go
@@ -15,21 +15,21 @@ const (
 	TestBurstSize = 10
 	// TestRefillRate is the default value for the rate limiter's refill rate.
 	TestRefillRate = 1.0
-	// TestURL is the URL to use for testing.
+	// TestHost is the URL to use for testing.
 	TestHost = "http://localhost:8080/"
 )
 
 func main() {
-	// Create a "tocket bucket" limiter with a burst size of 10 and a refill rate of 1.0/sec.
+	// Create a token bucket limiter with a burst size of 10 and a refill rate of 1.0/sec.
 	limiter := rate.NewLimiter(TestRefillRate, TestBurstSize)
 
 	// Create a new http.Client with the limiter.
 	client := &http.Client{
-		Transport: rltransport.New(limiter),
+		Transport: rltransport.New(rltransport.NewContextLimiter(limiter)),
 	}
 
 	// Make a request to the server.
-	// First 10 requests will be sented immadiately, after that it will be sented by 1.0 req/sec.
+	// First 10 requests will be sent immediately, then requests will be sent at 1.0 req/sec.
 	for i := 0; i < 20; i++ {
 		res, _ := client.Get(TestHost)
 		fmt.Printf("[%s] %s\n", time.Now().Format("2006-01-02 15:04:05"), res.Status)
@@ -46,7 +46,7 @@ func main() {
 	// [2022-04-06 20:11:09] 200 OK
 	// [2022-04-06 20:11:09] 200 OK
 	// [2022-04-06 20:11:09] 200 OK
-	// [2022-04-06 20:11:10] 200 OK  ## <-- First 10 requests will be sented immadiately.
+	// [2022-04-06 20:11:10] 200 OK  ## <-- First 10 requests will be sent immediately.
 	// [2022-04-06 20:11:11] 200 OK
 	// [2022-04-06 20:11:12] 200 OK
 	// [2022-04-06 20:11:13] 200 OK

--- a/limiter.go
+++ b/limiter.go
@@ -2,18 +2,53 @@ package rltransport
 
 import (
 	"context"
+	"net/http"
 )
 
 // Limiter is an interface that rate limiter must implement.
 type Limiter interface {
 	// Wait blocks until the request can be sent.
+	Wait(req *http.Request) error
+}
+
+// LimiterFunc adapts a function into a Limiter.
+type LimiterFunc func(req *http.Request) error
+
+// Wait blocks until the request can be sent.
+func (f LimiterFunc) Wait(req *http.Request) error {
+	return f(req)
+}
+
+// ContextLimiter is an interface for limiters that only need request context.
+type ContextLimiter interface {
+	// Wait blocks until the request can be sent.
 	Wait(ctx context.Context) error
+}
+
+// NewContextLimiter adapts a context-only limiter to the request-aware Limiter
+// interface. It treats nil as an unlimited limiter.
+func NewContextLimiter(limiter ContextLimiter) Limiter {
+	if limiter == nil {
+		return &unlimitedLimiter{}
+	}
+
+	return &contextLimiter{
+		limiter: limiter,
+	}
+}
+
+type contextLimiter struct {
+	limiter ContextLimiter
+}
+
+func (l *contextLimiter) Wait(req *http.Request) error {
+	return l.limiter.Wait(req.Context())
 }
 
 // unlimitedLimiter is a limiter that always allows requests to be sent.
 type unlimitedLimiter struct{}
 
-// Wait always success.
-func (l *unlimitedLimiter) Wait(_ context.Context) error {
+// Wait always succeeds.
+func (l *unlimitedLimiter) Wait(_ *http.Request) error {
 	return nil
 }

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -42,8 +42,8 @@ func (rt *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Ensure that the Transport is initialized.
 	rt.once.Do(rt.init)
 
-	// Wait for the rate limiter  within context of the request (if limiter is given).
-	if err := rt.Limiter.Wait(req.Context()); err != nil {
+	// Wait for the rate limiter with the full request.
+	if err := rt.Limiter.Wait(req); err != nil {
 		return nil, err
 	}
 

--- a/test/concurrent_limiter.go
+++ b/test/concurrent_limiter.go
@@ -1,8 +1,8 @@
 package test
 
 import (
-	"context"
 	"fmt"
+	"net/http"
 	"sync"
 )
 
@@ -18,8 +18,8 @@ func newConcurrentLimiter(limit int) *concurrentLimiter {
 	}
 }
 
-func (l *concurrentLimiter) Wait(ctx context.Context) error {
-	if err := ctx.Err(); err != nil {
+func (l *concurrentLimiter) Wait(req *http.Request) error {
+	if err := req.Context().Err(); err != nil {
 		return err
 	}
 

--- a/test/roundtripper_test.go
+++ b/test/roundtripper_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"net/http"
 	"sync"
 	"testing"
@@ -14,6 +15,17 @@ import (
 // RoundTripperTestSuite is a testify suite for RoundTripper
 type RoundTripperTestSuite struct {
 	suite.Suite
+}
+
+type contextCaptureLimiter struct {
+	count int
+	ctx   context.Context
+}
+
+func (l *contextCaptureLimiter) Wait(ctx context.Context) error {
+	l.count++
+	l.ctx = ctx
+	return nil
 }
 
 func (s *RoundTripperTestSuite) TestUnlimited() {
@@ -225,6 +237,45 @@ func (s *RoundTripperTestSuite) TestNewWithTransport() {
 			}
 		})
 	}
+}
+
+func (s *RoundTripperTestSuite) TestLimiterFuncReceivesRequest() {
+	monitor := NewMonitoringTripper()
+	var gotHost string
+
+	client := &http.Client{
+		Transport: rltransport.NewWithTransport(
+			rltransport.LimiterFunc(func(req *http.Request) error {
+				gotHost = req.URL.Host
+				return nil
+			}),
+			monitor,
+		),
+	}
+
+	_, err := client.Get("http://example.com")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "example.com", gotHost)
+	assert.Equal(s.T(), 1, monitor.Count())
+}
+
+func (s *RoundTripperTestSuite) TestNewContextLimiter() {
+	monitor := NewMonitoringTripper()
+	contextLimiter := &contextCaptureLimiter{}
+	limiter := rltransport.NewContextLimiter(contextLimiter)
+	requestContext := context.WithValue(context.Background(), "test-key", "test-value")
+	req, err := http.NewRequestWithContext(requestContext, http.MethodGet, "http://example.com", nil)
+	assert.NoError(s.T(), err)
+
+	client := &http.Client{
+		Transport: rltransport.NewWithTransport(limiter, monitor),
+	}
+
+	_, err = client.Do(req)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), 1, contextLimiter.count)
+	assert.Equal(s.T(), "test-value", contextLimiter.ctx.Value("test-key"))
+	assert.Equal(s.T(), 1, monitor.Count())
 }
 
 func (s *RoundTripperTestSuite) TestConcurrentRoundTrip() {

--- a/test/simple_limiter.go
+++ b/test/simple_limiter.go
@@ -1,8 +1,8 @@
 package test
 
 import (
-	"context"
 	"fmt"
+	"net/http"
 )
 
 type simpleLimiter struct {
@@ -10,7 +10,7 @@ type simpleLimiter struct {
 	Limit int
 }
 
-func (l *simpleLimiter) Wait(ctx context.Context) error {
+func (l *simpleLimiter) Wait(_ *http.Request) error {
 	if l.Count >= l.Limit {
 		return fmt.Errorf("limit exceeded")
 	}


### PR DESCRIPTION
## Summary

Make the `Limiter` interface request-aware by changing `Wait(ctx)` to `Wait(req)`.

## Background

Future limiter adapters, especially distributed limiters such as Redis-backed implementations, need access to request metadata such as host, path, headers, or context-derived values. Passing only `context.Context` makes those adapters awkward or impossible without side channels.

## Related issue(s)

None.

## Implementation details

- Changed `Limiter.Wait` to accept `*http.Request`.
- Updated `RoundTripper.RoundTrip` to pass the full request to the limiter.
- Added `LimiterFunc` for lightweight request-aware adapters.
- Added `ContextLimiter` and `NewContextLimiter` to adapt context-only limiters such as `golang.org/x/time/rate`.
- Updated test limiters, README, and the example app for the new interface.
- Added tests for request visibility and context-only limiter adaptation.

## Test coverage

- `make ci`
- `go test -count=1 ./...` in the root module
- `go test -count=1 ./...` in `test/`
- `go test -count=1 ./...` in `example/`
- `go test -race -count=1 ./...` in `test/`

## Breaking changes

`Limiter.Wait` now accepts `*http.Request` instead of `context.Context`. Existing custom limiter implementations must update their method signature. Context-only limiters can be wrapped with `NewContextLimiter`.

## Notes

Created by Codex